### PR TITLE
Add lab environment for dev1-signon okta

### DIFF
--- a/.github/workflows/deploy-serverless.yml
+++ b/.github/workflows/deploy-serverless.yml
@@ -6,6 +6,7 @@ on:
       # Automatically deploy main and staging. Additional branches may be added.
       - main
       - staging
+      - lab
   workflow_dispatch:
     # Allows manual build and deploy of any branch/ref
 

--- a/.github/workflows/deploy-serverless.yml
+++ b/.github/workflows/deploy-serverless.yml
@@ -6,7 +6,8 @@ on:
       # Automatically deploy main and staging. Additional branches may be added.
       - main
       - staging
-      - lab
+      # lab branch require `lab-` prefix
+      - lab-dev1
   workflow_dispatch:
     # Allows manual build and deploy of any branch/ref
 


### PR DESCRIPTION
This is going to require some updates to the deploy-serverless action as it seems like it deployed the `lab` branch to the staging lambda.