### PR TITLE
feat: add DRY_RUN mode to keypalive handler

### DIFF
--- a/handlers/keypalive.js
+++ b/handlers/keypalive.js
@@ -15,6 +15,12 @@ export const handler = async (event, context) => {
 
     const apiKeyPaths = process.env.API_KEY_PATHS.split(',')
     console.log(`API Key Paths: ${JSON.stringify(apiKeyPaths, null, 2)}`)
+
+    const dryRun = process.env.DRY_RUN === 'true'
+    if (dryRun) {
+      console.log(`DRY_RUN enabled: no keepalive calls will be executed. Would hit Okta org ${process.env.OKTA_ORG_URL} with ${apiKeyPaths.length} key(s): ${JSON.stringify(apiKeyPaths, null, 2)}`)
+    }
+
     const apiKeyPathChunks = apiKeyPaths.reduce((acc, _, index) => {
       acc.push(apiKeyPaths.slice(index, index + 10))
       return acc
@@ -31,6 +37,10 @@ export const handler = async (event, context) => {
             token: parameter.Value,
             cacheMiddleware: null,
           })
+          if (dryRun) {
+            console.log(`Keypalive [DRY_RUN]: skipping Okta call for ${parameter.Name}`)
+            continue
+          }
           const collection = await client.userApi.listUsers({
             search: 'profile.firstName sw "John"',
             limit: 1


### PR DESCRIPTION
When `DRY_RUN=true`, the handler runs every read-only step for real — env validation, SSM parameter fetch/decrypt (exercising IAM + KMS), and Okta client construction — but skips the mutating keepalive call (`userApi.listUsers`). It logs a summary up front (org URL, key paths, count) and a per-key skip line at the exact mutation boundary.

With `DRY_RUN` unset (every current deployment), behavior is byte-for-byte unchanged, so this is safe to merge and deploy ahead of the Terraform changes.

This supports the tenant-collapse restructure (CruGlobal/cru-terraform PR to follow): the stage environment becomes a dry-run release-candidate surface for the v2 pipeline — a candidate build proves config/permissions/connectivity on a cron without ever pinging Okta, then the same image is promoted to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)