### PR TITLE
feat: adopt pipeline v2 (build-once / promote)

### DIFF
--- a/.github/workflows/build-deploy-lambda.yml
+++ b/.github/workflows/build-deploy-lambda.yml
@@ -1,13 +1,13 @@
 name: Build & Deploy Lambda
 
 on:
-  push:
-    branches:
-      # Automatically deploy main. Additional branches may be added.
-      - main
-      - staging
-      # lab branch require `lab-` prefix
-      - lab-dev1
+  # v1 pipeline parked during the pipeline-v2 pilot — pipeline-v2.yml now builds
+  # and deploys via the v2 build-once/promote flow. Escape hatch: run this
+  # workflow manually from the Actions tab (workflow_dispatch), optionally with
+  # auto-deploy=true; restore the push triggers below to fully revert to v1.
+  #
+  # The old push branch mappings (main/staging/lab-dev1) are retired: stage is
+  # now the v2 release-candidate surface, and the lab env was collapsed into prod.
   workflow_dispatch:
     # Allows manual build and deploy of any branch/ref
     inputs:

--- a/.github/workflows/pipeline-v2.yml
+++ b/.github/workflows/pipeline-v2.yml
@@ -1,0 +1,39 @@
+# Pilot workflow for the v2 build-once / promote pipeline (Lambda).
+#
+# Pinned to the `pipeline-v2` branch of CruGlobal/.github (both the reusable
+# workflow and the actions) and passes workflow-ref: pipeline-v2 so the actions
+# the reusable workflow checks out match. Re-pin every `@pipeline-v2` reference
+# and the workflow-ref input to `@v2` at release.
+name: Pipeline v2
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build candidate
+    uses: CruGlobal/.github/.github/workflows/build-candidate.yml@pipeline-v2
+    # build-candidate's lambda job authenticates to AWS via OIDC (the app's
+    # prod GitHubRole), so the caller must grant id-token: write — a reusable
+    # workflow can only downgrade, never elevate, the caller's permissions.
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      workflow-ref: pipeline-v2
+      type: lambda
+
+  deploy-release-candidate:
+    name: Deploy to release-candidate
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: CruGlobal/.github/actions/dispatch@pipeline-v2
+        with:
+          github-token: ${{ secrets.CRU_DEPLOY_GITHUB_TOKEN }}
+          workflow: deploy-candidate.yml
+          inputs-json: >-
+            {"project-name": "${{ needs.build.outputs.project-name }}",
+             "tag": "${{ needs.build.outputs.candidate }}"}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,7 @@ ARG NODE_VERSION=latest
 # Use AWS Lambda Node.js base image for the final image
 FROM public.ecr.aws/lambda/nodejs:${NODE_VERSION}
 
-# Define GitHub Action Build Args
-ARG PROJECT_NAME
-ARG ENVIRONMENT
-ARG BUILD_NUMBER
-
 # Set environment variables for the Lambda function
-ENV PROJECT_NAME=${PROJECT_NAME}
-ENV ENVIRONMENT=${ENVIRONMENT}
-ENV BUILD_NUMBER=${BUILD_NUMBER}
 ENV NODE_OPTIONS=--enable-source-maps
 
 # Set the Lambda task root directory


### PR DESCRIPTION
Moves okta-api-keypalive onto the v2 build-once/promote pipeline — the Lambda pilot, following hoax (CloudRun) and tachyon-app (ECS).

## What changes

- **`pipeline-v2.yml`** (new): on push to main, builds one env-neutral candidate image (`candidate-<n>` + `sha-<gitsha>` in the app's ECR repo) with the app's prod GitHubRole, then dispatches a release-candidate deploy via cru-deploy. Stage — the DRY_RUN=true rc surface from the tenant collapse — receives the candidate; its cron (or a manual invoke) validates config/permissions/connectivity without pinging Okta. Promote/rollback run from cru-deploy by digest, exactly as the other pilots.
- **v1 parked**: `build-deploy-lambda.yml` keeps only `workflow_dispatch` (with the existing `auto-deploy` input) as the escape hatch. The old branch→env mappings are retired — stage is the rc surface and lab was collapsed into prod.
- **Dockerfile**: drops the `ARG`/`ENV` baking of `PROJECT_NAME` / `ENVIRONMENT` / `BUILD_NUMBER`. Candidates are env-neutral: the aws/lambda/app module injects `PROJECT_NAME` and `ENVIRONMENT` as function env vars at runtime, and `BUILD_NUMBER` is referenced nowhere in the app.

## Merge order

1. CruGlobal/.github `pipeline-v2` branch already carries the Lambda pass (pushed) — this workflow pins `@pipeline-v2`.
2. Apply CruGlobal/cru-terraform#11376 (`ecr:PutImage` on GitHubDeployLambda) before the first **promote**; builds and rc deploys work without it.
3. Merge this PR → first candidate builds and lands on stage.

Promotion gate for this app: candidate on stage runs DRY_RUN green → promote the same digest to prod (updates all three tenant functions, digest-pinned, waits for each update to go live) → `release-<n>` stamped on the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)