### PR TITLE
fix: chunk API key paths without overlap

### DIFF
--- a/handlers/keypalive.js
+++ b/handlers/keypalive.js
@@ -21,8 +21,9 @@ export const handler = async (event, context) => {
       console.log(`DRY_RUN enabled: no keepalive calls will be executed. Would hit Okta org ${process.env.OKTA_ORG_URL} with ${apiKeyPaths.length} key(s): ${JSON.stringify(apiKeyPaths, null, 2)}`)
     }
 
+    // Chunk into groups of 10 (GetParameters accepts at most 10 names per call).
     const apiKeyPathChunks = apiKeyPaths.reduce((acc, _, index) => {
-      acc.push(apiKeyPaths.slice(index, index + 10))
+      if (index % 10 === 0) acc.push(apiKeyPaths.slice(index, index + 10))
       return acc
     }, [])
 


### PR DESCRIPTION
The chunking `reduce` built one window per index (`slice(index, index+10)`), so path *i* was fetched and pinged *i+1* times per run — 28 Okta calls for okta-prod's 7 paths, and the reason the recent bills 401 spammed 5× per run. Chunk on every 10th index instead: each path lands in exactly one `GetParameters` call (10-name API limit) and gets exactly one keepalive ping. Verified across sizes 1–25: no overlap, none missed.

**Hold merge — this is the pilot's rollback-test commit.** Sequencing: once cru-terraform#11377 is applied and `candidate-10055` is promoted, merging this builds candidate #2. The behavior change is log-visible (ping counts drop from i+1 to 1), so the rollback verification is direct: roll back to release #1 and the duplicate pings reappear in the logs; roll forward and they're gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)