### PR TITLE
build: record which secrets-lambda-extension version gets baked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,16 @@ RUN npm run build
 
 # Download and extract the secrets-lambda-extension
 FROM public.ecr.aws/docker/library/alpine:latest AS extension
-RUN mkdir -p /opt/secrets-lambda-extension && \
-    wget https://github.com/CruGlobal/secrets-lambda-extension/releases/latest/download/secrets-lambda-extension-linux-amd64.tar.gz -q -O - |tar -xzC /opt/secrets-lambda-extension/
+# Deliberately tracks the LATEST extension release (pinned versions rotted in
+# Dockerfiles fleet-wide; under build-once the artifact itself is the pin and a
+# bad release is caught on the release-candidate surface). Resolve `latest`
+# once, record what was baked, then fetch that exact version.
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/secrets-lambda-extension && \
+    version=$(curl -fsIL -o /dev/null -w '%{url_effective}' https://github.com/CruGlobal/secrets-lambda-extension/releases/latest | sed 's|.*/tag/||') && \
+    echo "secrets-lambda-extension: ${version}" && \
+    echo "${version}" > /opt/secrets-lambda-extension/VERSION && \
+    wget "https://github.com/CruGlobal/secrets-lambda-extension/releases/download/${version}/secrets-lambda-extension-linux-amd64.tar.gz" -q -O - |tar -xzC /opt/secrets-lambda-extension/
 
 # NODE_VERSION set by build.sh based on .tool-versions file
 ARG NODE_VERSION=latest


### PR DESCRIPTION
Revised after discussion — **keeps `releases/latest`**, deliberately: pinned versions rotted in Dockerfiles fleet-wide (the observed failure), and under build-once the artifact itself is the pin — a bad extension release is caught on the release-candidate surface at the next build, and rollback restores an image with the old extension baked in regardless of what `latest` points to.

What changes: resolve `latest` **once**, log the resolved version in the build output, stamp it into `/opt/secrets-lambda-extension/VERSION` (ships in the final image), and download that exact artifact. Any image can now answer "which extension am I running" during an incident; builds within a single run can't race a mid-build release.

**Hold merge — this is the pilot's second candidate.** Sequencing: promote `candidate-2026-07-23-10056` first (release #1), then merge this to build candidate #2 → stage dry-run → promote (release #2) → rollback/roll-forward exit condition between the two releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)