### PR TITLE
chore: bake DD_VERSION from the pipeline VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,8 @@ CMD ["node_modules/datadog-lambda-js/dist/handler.handler"]
 
 # Copy the built application from the builder stage
 COPY --from=builder /app/dist/* ./
+
+# Build identity -> Datadog version (D10 bare suffix, e.g. 2026-07-24-10058).
+# Passed by build-candidate as --build-arg VERSION; "dev" for local builds.
+ARG VERSION="dev"
+ENV DD_VERSION=${VERSION}


### PR DESCRIPTION
Two lines at the end of the Dockerfile (zero build-cache cost): the candidate build passes `--build-arg VERSION=<yyyy-mm-dd>-<n>` — the D10 tag suffix, identical for the candidate and its future release — and the image bakes it as `DD_VERSION`. One true version per build in every environment, all runtimes including Lambda, no deploy-time env mutation, no Terraform drift. Apps without the ARG keep working (unused build-arg warning only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)