### PR TITLE
chore: nightly build at 05:00 UTC (midnight-ish Eastern, off-peak dispatch)

### DIFF
--- a/.github/workflows/pipeline-v2.yml
+++ b/.github/workflows/pipeline-v2.yml
@@ -8,11 +8,14 @@
 # semantics: an already-built sha is reused rather than rebuilt, and a force
 # redeploy is available on cru-deploy's Deploy Candidate (v2) dispatch.
 #
-# The whole v2 fleet builds nightly at midnight UTC — one shared slot, no
-# staggering. GitHub's scheduled dispatch is best-effort, and top-of-hour
-# crons (00:00 UTC most of all) sit in the busiest queue: a nightly run can
-# start many minutes after the nominal time when the shared scheduler is under
-# load. That lateness is expected, not a failure.
+# The whole v2 fleet builds nightly at 05:00 UTC — midnight EST, 1am EDT. The
+# clock time drifts an hour across DST, which is the deliberate wobble of a
+# fixed-UTC cron and perfectly tolerable for a nightly. It is still one shared
+# slot for the whole fleet, with no staggering. 05:00 UTC is off-peak on
+# GitHub's scheduler, so dispatch lag is minimal — unlike 00:00 UTC, the
+# busiest cron minute on GitHub, where runs routinely started many minutes
+# late. Scheduled dispatch is still best-effort, so a few minutes of lateness
+# is expected, not a failure.
 #
 # Pinned to the `pipeline-v2` branch of CruGlobal/.github (both the reusable
 # workflow and the actions) and passes workflow-ref: pipeline-v2 so the actions
@@ -23,7 +26,7 @@ name: Pipeline v2
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 5 * * *'
 
 jobs:
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,11 +94,12 @@ referenced anywhere, the reference is stale.
    no "Validate PR Title" check wired up yet, so nothing enforces it
    mechanically.)
 2. **Builds do not run on push.** `.github/workflows/pipeline-v2.yml` runs on a
-   **nightly cron at midnight UTC** (`cron: '0 0 * * *'` — one unstaggered slot
-   shared by the whole v2 fleet) and on manual **`workflow_dispatch`**. Merging
-   to `main` does not deploy anything by itself. GitHub's scheduled dispatch is
-   best-effort and top-of-hour crons queue: a nightly that starts several
-   minutes late is expected, not a failure.
+   **nightly cron at 05:00 UTC** (`cron: '0 5 * * *'` — midnight EST / 1am EDT,
+   one unstaggered slot shared by the whole v2 fleet) and on manual
+   **`workflow_dispatch`**. Merging to `main` does not deploy anything by
+   itself. 05:00 UTC is off-peak on GitHub's scheduler, so dispatch lag is
+   minimal — but scheduled dispatch is still best-effort, so a nightly that
+   starts a few minutes late is expected, not a failure.
 3. **A build produces a candidate.** It pushes `candidate-<yyyy-mm-dd>-<n>` and
    `sha-<gitsha>` to the app's ECR repo
    (`056154071827.dkr.ecr.us-east-1.amazonaws.com/okta-api-keypalive`), then


### PR DESCRIPTION
Rolls this repo's pipeline-v2 nightly cron from `'0 0 * * *'` to `'0 5 * * *'`, part of a ratified fleet-wide change across all six v2 app repos.

**Why 05:00 UTC**

- It is **midnight EST / 1am EDT** — the nightly lands in the small hours Eastern year-round. The one-hour clock-time drift across DST is the deliberate wobble of a fixed-UTC cron, and it is entirely tolerable for a nightly.
- It is **off-peak on GitHub's shared scheduler**. `00:00 UTC` is the single busiest cron minute on GitHub, and scheduled runs there routinely started many minutes after the nominal time. At 05:00 UTC that dispatch lag mostly disappears. Scheduled dispatch is still best-effort, so a few minutes late remains expected rather than a failure.
- Still **one unstaggered slot** shared by the whole v2 fleet — this change moves the slot, it does not spread the fleet out.

The workflow header comment and any repo docs stating the midnight-UTC time are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
