### PR TITLE
chore: remove the merge-bot config (v2 has no staging branch)

### DIFF
--- a/.github/merge-bot.yml
+++ b/.github/merge-bot.yml
@@ -1,1 +1,0 @@
-enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,8 +188,6 @@ Watch a run with `gh run watch`, or the Actions tab here (build) and in
 
 ## Leftovers you can ignore
 
-- `.github/merge-bot.yml` — v1 merge-bot config. The v2 flow has no `staging`
-  branch for it to act on.
 - Stale `staging` and `lab-dev1` branches still exist on the remote; the lab
   environment was collapsed into prod. `main` is the only live branch.
 


### PR DESCRIPTION
`.github/merge-bot.yml` is the config that **enables** the "On Staging" merge bot. This repo is on pipeline v2, which has no `staging` branch and no `On Staging` label — the only two things that bot ever acted on. Leaving the config in place is the one thing that could switch the bot back on, so it goes.

Ratified with Brian, who owns the merge bot: pipeline-v2 repos must not carry `merge-bot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)