### PR TITLE
chore: grouped dependabot updates (fleet standard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+# The commit-message prefixes make Dependabot's PR titles valid Conventional
+# Commits ("deps(npm): bump rollbar ..." rather than "Bump rollbar ...").
+# okta-api-keypalive has no "Validate PR Title" check today, so nothing enforces
+# them yet — they are here so the titles are already correct when the
+# conventional-commits workflow and the required check land, and so the squash
+# subjects that feed the deploy changelog read consistently with the rest of the
+# v2 fleet.
+updates:
+  # ──────────────────────────────────────────────────────────────────────────
+  # npm dependencies. Minor and patch bumps across both runtime and dev
+  # dependencies are batched into a single weekly PR to keep review cost flat.
+  # Major version bumps are intentionally left ungrouped so each one gets its
+  # own PR and a proper migration check — the AWS SDK and Okta SDK clients are
+  # the ones most likely to need it.
+  # ──────────────────────────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # GitHub Actions used by .github/workflows/**. Same policy: one batched PR
+  # per week for minor + patch bumps; majors stay per-PR so any breaking change
+  # in an action surface surfaces distinctly.
+  # ──────────────────────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Adds `.github/dependabot.yml` — okta-api-keypalive had none, so nothing was tracking dependency or action updates. Matches the fleet standard for pipeline-v2 repos (`cru-app-info`, `bills`): **grouped** minor + patch updates with conventional-commit prefixes.

## Structure

| ecosystem | group name | grouped update types | schedule | limit | prefix |
| --- | --- | --- | --- | --- | --- |
| `npm` | `npm-dependencies` (`patterns: ["*"]`) | `minor`, `patch` | weekly | 5 | `deps` |
| `github-actions` | `github-actions` (`patterns: ["*"]`) | `minor`, `patch` | weekly | 3 | `ci` |

One batched PR per ecosystem per week for minor/patch; majors stay ungrouped so each gets its own PR and a migration check — relevant here for `@aws-sdk/client-ssm` and `@okta/okta-sdk-nodejs`, which move fast.

No `@types/node` ignore rule (unlike the `bills`/`hoax` configs) — this repo has no `@types/node` dependency.

## What actually gates these merges — read this

Two gaps found while doing this, both worth a decision:

1. **No required status checks.** The `pipeline-v2-default-branch` ruleset has `deletion`, `required_linear_history`, `non_fast_forward` and `pull_request` (with `required_approving_review_count: 0`) — and **no `required_status_checks` rule at all**. There is no CI workflow and no `conventional-commits.yml`, so the **Validate PR Title** check does not exist in this repo either. The `deps`/`ci` prefixes here are forward-looking — correct titles for when that workflow and required check land.
2. **No auto-merge workflow.** No `.github/workflows/dependabot-auto-merge.yml` here (29 other CruGlobal repos have one). So nothing will approve or auto-merge these PRs today.

Net effect as things stand: grouped Dependabot PRs will open weekly and **sit open until a human merges them** — nothing verifies them and nothing merges them. If that workflow is added as-is, the situation flips to the opposite extreme: with no required checks in the ruleset, GitHub auto-merge falls through to an **immediate merge**, so minor/patch dependency bumps would land on `main` with zero verification. Worth adding a minimal CI check (`npm run lint` / `npm run build` + `Validate PR Title`) to the ruleset before, or together with, the auto-merge workflow.
