### PR TITLE
ci: pin pipeline workflows to the released v2 tag

### DIFF
--- a/.github/workflows/pipeline-v2.yml
+++ b/.github/workflows/pipeline-v2.yml
@@ -17,10 +17,9 @@
 # late. Scheduled dispatch is still best-effort, so a few minutes of lateness
 # is expected, not a failure.
 #
-# Pinned to the `pipeline-v2` branch of CruGlobal/.github (both the reusable
-# workflow and the actions) and passes workflow-ref: pipeline-v2 so the actions
-# the reusable workflow checks out match. Re-pin every `@pipeline-v2` reference
-# and the workflow-ref input to `@v2` at release.
+# Pinned to the released `v2` tag of CruGlobal/.github (both the reusable
+# workflow and the actions) and passes workflow-ref: v2 so the actions the
+# reusable workflow checks out match. `v2` tracks the latest v2.x release.
 name: Pipeline v2
 
 on:
@@ -31,7 +30,7 @@ on:
 jobs:
   build:
     name: Build candidate
-    uses: CruGlobal/.github/.github/workflows/build-candidate.yml@pipeline-v2
+    uses: CruGlobal/.github/.github/workflows/build-candidate.yml@v2
     # build-candidate's lambda job authenticates to AWS via OIDC (the app's
     # prod GitHubRole), so the caller must grant id-token: write — a reusable
     # workflow can only downgrade, never elevate, the caller's permissions.
@@ -39,7 +38,7 @@ jobs:
       id-token: write
       contents: read
     with:
-      workflow-ref: pipeline-v2
+      workflow-ref: v2
       type: lambda
     # BUILD-time secrets are repo secrets named BUILD_<NAME> (D2): inherit hands
     # them to the reusable workflow, which exports ONLY the BUILD_* keys into
@@ -51,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: CruGlobal/.github/actions/dispatch@pipeline-v2
+      - uses: CruGlobal/.github/actions/dispatch@v2
         with:
           github-token: ${{ secrets.CRU_DEPLOY_GITHUB_TOKEN }}
           workflow: deploy-candidate.yml


### PR DESCRIPTION
Pipeline v2.0.0 is released; this re-pins the workflow references from the development branch to the released tag. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)